### PR TITLE
fix: SOF-1016 missing mediaId on mediaObjects

### DIFF
--- a/src/monitors/watcher.ts
+++ b/src/monitors/watcher.ts
@@ -157,6 +157,7 @@ export class Watcher extends EventEmitter {
 			doc.mediaPath = mediaPath
 			doc.mediaSize = mediaStat.size
 			doc.mediaTime = mediaStat.mtime.getTime()
+			doc.mediaId = mediaId
 
 			// Assuming generateInfoWhenFound is always false - use work steps
 			// if (generateInfoWhenFound) { // Check if basic file probe should be run in manualMode


### PR DESCRIPTION
It caused `Unhandled Promise rejection: TypeError: Cannot read property 'startsWith' of undefined` [here](https://github.com/tv2/tv-automation-media-management/blob/0d3adbacfb988892b914b60efbd816d4034edbe4/src/monitors/watcher.ts#L225)