### PR TITLE
fix: prevent duplicated workflows after reconnecting to Core

### DIFF
--- a/src/coreHandler.ts
+++ b/src/coreHandler.ts
@@ -143,6 +143,7 @@ export class CoreHandler {
 		observer.changed = (id1: string) => {
 			this.onDeviceChanged(id1)
 		}
+		this._observers.push(observer)
 		this.setupObserverForPeripheralDeviceCommands(this)
 		return
 	}

--- a/src/workflowGenerators/expectedItemsGenerator.ts
+++ b/src/workflowGenerators/expectedItemsGenerator.ts
@@ -128,6 +128,9 @@ export class ExpectedItemsGenerator extends BaseWorkFlowGenerator {
 		if (this._expectedMediaItemsSubscription) {
 			this._coreHandler.core.unsubscribe(this._expectedMediaItemsSubscription)
 		}
+		if (this.observer) {
+			this.observer.stop()
+		}
 		this._expectedMediaItemsSubscription = await this._coreHandler.core.subscribe('expectedMediaItems', {
 			mediaFlowId: {
 				$in: _.keys(this._handledFlows)


### PR DESCRIPTION
stop the expectedMediaItems and peripheralDevices observers when reconnected