### PR TITLE
fix: Local folder supports posix paths.

### DIFF
--- a/src/storageHandlers/localFolderHandler.ts
+++ b/src/storageHandlers/localFolderHandler.ts
@@ -11,6 +11,7 @@ import { CancelablePromise } from '../lib/cancelablePromise'
 import { LoggerInstance } from 'winston'
 import { FileShareWatcherType } from '../configManifest'
 import { FastSelectFileWatcher } from './fastSelectFileWatcher'
+import * as process from 'process'
 
 /**
  * A shared method to get the file properties from the underlying file system.
@@ -364,8 +365,12 @@ export class LocalFolderHandler extends EventEmitter implements StorageHandler {
 	}
 
 	parseUrl(url: string): string {
-		if (url.startsWith(this._basePath)) {
-			return url.substr(this._basePath.length).replace(/^\\/, '')
+		const isWindowsPlatform: boolean = process.platform === 'win32'
+		const platformUrl: string = isWindowsPlatform
+			? url.replace(/^\\/, '')
+			: url.replace(/^\\\\/, '/').replace(/\\/g, '/')
+		if (platformUrl.startsWith(this._basePath)) {
+			return platformUrl.substr(this._basePath.length)
 		}
 		throw new Error(`This storage handler does not support file URL "${url}"`)
 	}

--- a/src/storageHandlers/localFolderHandler.ts
+++ b/src/storageHandlers/localFolderHandler.ts
@@ -369,7 +369,7 @@ export class LocalFolderHandler extends EventEmitter implements StorageHandler {
 		const platformUrl: string = isWindowsPlatform
 			? url.replace(/^\\/, '')
 			: url.replace(/^\\\\/, '/').replace(/\\/g, '/')
-		if (platformUrl.startsWith(this._basePath)) {
+		if (platformUrl.startsWith(this._basePath.replace(/^\\/, ''))) {
 			return platformUrl.substr(this._basePath.length)
 		}
 		throw new Error(`This storage handler does not support file URL "${url}"`)


### PR DESCRIPTION
Local folder url parser posix path formatting for non-windows platforms. This change should be enough to run media manager for testing purposes on a Mac or linux machine.